### PR TITLE
Added and populated a 'DumbsterAllRecipients' header to allow testing for BCC recipients

### DIFF
--- a/src/com/dumbster/smtp/ClientSession.java
+++ b/src/com/dumbster/smtp/ClientSession.java
@@ -6,7 +6,7 @@ import java.io.PrintWriter;
 
 public class ClientSession implements Runnable {
 
-    protected static final String DUMBSTER_ALL_RECIPIENTS_HEADER = "DumbsterAllRecipients";
+    protected static final String DUMBSTER_ALL_RECIPIENTS_HEADER = "X-DumbsterAllRecipients";
 
     private IOSource socket;
     private volatile MailStore mailStore;
@@ -101,7 +101,7 @@ public class ClientSession implements Runnable {
         if (null == params)
             return;
 
-        if (SmtpState.RCPT == request.getState()) {
+        if (SmtpState.RCPT.equals(request.getState())) {
             addDataHeader(DUMBSTER_ALL_RECIPIENTS_HEADER + ":" + params);
         }
 
@@ -110,7 +110,7 @@ public class ClientSession implements Runnable {
             return;
         }
 
-        if (SmtpState.DATA_BODY == smtpResponse.getNextState()) {
+        if (SmtpState.DATA_BODY.equals(smtpResponse.getNextState())) {
             msg.appendBody(params);
             return;
         }

--- a/src/com/dumbster/smtp/ClientSession.java
+++ b/src/com/dumbster/smtp/ClientSession.java
@@ -6,6 +6,8 @@ import java.io.PrintWriter;
 
 public class ClientSession implements Runnable {
 
+    protected static final String DUMBSTER_ALL_RECIPIENTS_HEADER = "DumbsterAllRecipients";
+
     private IOSource socket;
     private volatile MailStore mailStore;
     private MailMessage msg;
@@ -98,6 +100,10 @@ public class ClientSession implements Runnable {
         String params = request.getParams();
         if (null == params)
             return;
+
+        if (SmtpState.RCPT == request.getState()) {
+            addDataHeader(DUMBSTER_ALL_RECIPIENTS_HEADER + ":" + params);
+        }
 
         if (SmtpState.DATA_HDR.equals(smtpResponse.getNextState())) {
             addDataHeader(params);


### PR DESCRIPTION
There is (for obvious reasons) no email header that gives details of bcc recipients - which can cause problems for unit testing. This commit adds a custom 'DumbsterAllRecipients' header which includes To, cc, and bcc recipients, thus allowing unit testing.
